### PR TITLE
fix: `nvim-nightly` -> `nvim-unstable`

### DIFF
--- a/modules/home/nvim/default.nix
+++ b/modules/home/nvim/default.nix
@@ -22,7 +22,7 @@
   ];
   neovim = {
     enable = true;
-    package = pkgs.neovim-nightly;
+    package = pkgs.neovim;
     viAlias = true;
     vimAlias = true;
     vimdiffAlias = true;


### PR DESCRIPTION
* stay on the unstable version for now, until `0.7` api changes have propagated to the plugins