### PR TITLE
nvim: `ruff-lsp` -> `ruff`

### DIFF
--- a/home/nvim/lua/kenji/lsp/init.lua
+++ b/home/nvim/lua/kenji/lsp/init.lua
@@ -99,7 +99,7 @@ require("lspconfig").rust_analyzer.setup({
 	},
 })
 
-require("lspconfig").ruff_lsp.setup({})
+require("lspconfig").ruff.setup({})
 require("lspconfig").gopls.setup({})
 require("lspconfig").mutt_ls.setup({})
 

--- a/modules/home/tools/default.nix
+++ b/modules/home/tools/default.nix
@@ -22,7 +22,6 @@ let
   language-servers = with pkgs; [
     clang-tools
     marksman
-    ruff-lsp
     ruff
     nil
     nixd


### PR DESCRIPTION
`ruff-lsp` is deprecated in favor of `ruff`
